### PR TITLE
refactor: use Microsoft.Data.SqlClient

### DIFF
--- a/Flashcards/DataAccess/DataContext.cs
+++ b/Flashcards/DataAccess/DataContext.cs
@@ -1,6 +1,6 @@
 ﻿using Dapper;
+using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Configuration;
-using System.Data.SqlClient;
 
 namespace Flashcards.DataAccess;
 

--- a/Flashcards/DataAccess/Repositories/FlashcardsRepository.cs
+++ b/Flashcards/DataAccess/Repositories/FlashcardsRepository.cs
@@ -2,8 +2,8 @@
 using Flashcards.DataAccess.Interfaces;
 using Flashcards.Models;
 using Flashcards.Utils;
+using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Configuration;
-using System.Data.SqlClient;
 
 namespace Flashcards.DataAccess.Repositories;
 

--- a/Flashcards/DataAccess/Repositories/StacksRepository.cs
+++ b/Flashcards/DataAccess/Repositories/StacksRepository.cs
@@ -2,8 +2,8 @@
 using Flashcards.DataAccess.Interfaces;
 using Flashcards.Models;
 using Flashcards.Utils;
+using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Configuration;
-using System.Data.SqlClient;
 
 namespace Flashcards.DataAccess.Repositories;
 

--- a/Flashcards/DataAccess/Repositories/StudySessionsRepository.cs
+++ b/Flashcards/DataAccess/Repositories/StudySessionsRepository.cs
@@ -2,8 +2,8 @@
 using Flashcards.DataAccess.Interfaces;
 using Flashcards.Models;
 using Flashcards.Utils;
+using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Configuration;
-using System.Data.SqlClient;
 
 namespace Flashcards.DataAccess.Repositories;
 

--- a/Flashcards/Flashcards.csproj
+++ b/Flashcards/Flashcards.csproj
@@ -9,12 +9,12 @@
 
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.1.66" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.7" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.7" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.7" />
     <PackageReference Include="Spectre.Console" Version="0.50.0" />
     <PackageReference Include="Spectre.Console.Cli" Version="0.50.0" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.9.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
#### Summary
This pull request updates the project to use `Microsoft.Data.SqlClient` instead of `System.Data.SqlClient`, enhancing compatibility and performance.

#### Changes
- DataContext.cs: Replaced `using System.Data.SqlClient` with `using Microsoft.Data.SqlClient`.
- FlashcardsRepository.cs: Updated to use `Microsoft.Data.SqlClient` and removed `System.Data.SqlClient`.
- StacksRepository.cs: Changed to `Microsoft.Data.SqlClient` and removed the old reference.
- StudySessionsRepository.cs: Switched to `Microsoft.Data.SqlClient` and removed `System.Data.SqlClient`.
- Flashcards.csproj: Added `Microsoft.Data.SqlClient` package and removed `System.Data.SqlClient` package.
