### PR TITLE
feat: implement multiple choice card functionality

### DIFF
--- a/Flashcards.IntegrationTests/StudySessionsServiceIntegrationTests.cs
+++ b/Flashcards.IntegrationTests/StudySessionsServiceIntegrationTests.cs
@@ -33,6 +33,8 @@ public class StudySessionsServiceIntegrationTests : BaseIntegrationTest, IAsyncL
         var cardDTOs = cards.Select(Mapper.ToCardDTO).ToList();
 
         _userInteractionService.GetAnswer().Returns("Good morning", "Goodbye", "Please");
+        _userInteractionService.GetMultipleChoiceAnswers(Arg.Any<List<string>>())
+            .Returns(["Warszawa"], ["Wisła", "Odra", "Warta"], ["Szesnaście"]);
 
         // Act
         var result = await _studySessionsService.RunStudySessionAsync(cardDTOs, stackId);

--- a/Flashcards.UnitTests/Services/StudySessionsServiceTests.cs
+++ b/Flashcards.UnitTests/Services/StudySessionsServiceTests.cs
@@ -373,4 +373,29 @@ public class StudySessionsServiceTests
         // Assert
         Assert.True(result.IsSuccess);
     }
+
+    [Theory]
+    [InlineData(new string[] { "A", "B" }, new string[] { "A", "B" }, true)]
+    [InlineData(new string[] { "B", "A" }, new string[] { "A", "B" }, true)]
+    [InlineData(new string[] { "A" }, new string[] { "A", "B" }, false)]
+    [InlineData(new string[] { "A", "B", "C" }, new string[] { "A", "B" }, false)]
+    [InlineData(new string[] { "A", "C" }, new string[] { "A", "B" }, false)]
+    [InlineData(new string[] { }, new string[] { }, true)]
+    [InlineData(new string[] { "A" }, new string[] { }, false)]
+    public void IsCorrectMultipleChoiceCardAnswer_ShouldReturnCorrectResult_WhenComparingAnswers(string[] userAnswers, string[] correctAnswers, bool expected)
+    {
+        // Arrange
+        var userAnswersList = userAnswers.ToList();
+        var correctAnswersList = correctAnswers.ToList();
+
+        // Use reflection to access the private method
+        var method = typeof(StudySessionsService).GetMethod("IsCorrectMultipleChoiceCardAnswer",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+
+        // Act
+        var result = (bool)method!.Invoke(_studySessionsService, new object[] { userAnswersList, correctAnswersList });
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
 }

--- a/Flashcards.UnitTests/Services/StudySessionsServiceTests.cs
+++ b/Flashcards.UnitTests/Services/StudySessionsServiceTests.cs
@@ -26,58 +26,33 @@ public class StudySessionsServiceTests
         );
     }
 
-    public static IEnumerable<object[]> StartStudySessionTestData =>
-        new List<object[]>
-        {
-            new object[]
-            {
-                new List<BaseCardDTO>
-                {
-                    new FlashcardDTO { Front = "Dog", Back = "Pies" },
-                    new FlashcardDTO { Front = "Cat", Back = "Kot" }
-                },
-                new List<string> { "Pies", "Kot" },
-                2
-            },
-            new object[]
-            {
-                new List<BaseCardDTO>
-                {
-                    new FlashcardDTO { Front = "Front3", Back = "Back3" }
-                },
-                new List<string> { "Back3" },
-                1
-            },
-            new object[]
-            {
-                new List<BaseCardDTO>(),
-                new List<string>(),
-                0
-            },
-            new object[]
-            {
-                new List<BaseCardDTO>
-                {
-                    new FlashcardDTO { Front = "Front4", Back = "Back4" },
-                },
-                new List<string> { "WrongAnswer" },
-                0
-            }
-        };
-
-    [Theory]
-    [MemberData(nameof(StartStudySessionTestData))]
-    public void StartStudySessionAsync_ShouldCalculateCorrectScore_WhenAnswersProvided(List<BaseCardDTO> cards, List<string> userAnswers, int expectedScore)
+    [Fact]
+    public void StartStudySessionAsync_ShouldCalculateCorrectScore_WhenMixedCardTypes()
     {
         // Arrange
-        int i = 0;
-        _userInteractionService.GetAnswer().Returns(_ => userAnswers[i++]);
+        var flashcard = new FlashcardDTO { Id = 1, Front = "Hello", Back = "Hola" };
+        var multipleChoiceCard = new MultipleChoiceCardDTO
+        {
+            Id = 2,
+            Question = "Which is a fruit?",
+            Choices = new List<string> { "Apple", "Car", "Book" },
+            Answer = new List<string> { "Apple" },
+            CardType = CardType.MultipleChoice
+        };
+        var cards = new List<BaseCardDTO> { flashcard, multipleChoiceCard };
+
+        int answerCallCount = 0;
+        _userInteractionService.GetAnswer().Returns(_ => answerCallCount++ == 0 ? "Hola" : "");
+        _userInteractionService.GetMultipleChoiceAnswers(Arg.Any<List<string>>())
+            .Returns(new List<string> { "Apple" });
 
         // Act
         _studySessionsService.StartStudySessionAsync(cards);
 
         // Assert
-        Assert.Equal(expectedScore, _studySessionsService.Score);
+        Assert.Equal(2, _studySessionsService.Score);
+        _userInteractionService.Received(1).GetAnswer();
+        _userInteractionService.Received(1).GetMultipleChoiceAnswers(multipleChoiceCard.Choices);
     }
 
     [Fact]
@@ -187,6 +162,29 @@ public class StudySessionsServiceTests
         Assert.Equal(2, result.Value.Count);
         Assert.Equal(1, result.Value[0].Id);
         Assert.Equal(2, result.Value[1].Id);
+    }
+
+    [Fact]
+    public void StartStudySessionAsync_ShouldResetScore_WhenCalledMultipleTimes()
+    {
+        // Arrange
+        var flashcard1 = new FlashcardDTO { Id = 1, Front = "Hello", Back = "Hola" };
+        var flashcard2 = new FlashcardDTO { Id = 2, Front = "Goodbye", Back = "Adiós" };
+        var cards1 = new List<BaseCardDTO> { flashcard1 };
+        var cards2 = new List<BaseCardDTO> { flashcard2 };
+
+        _userInteractionService.GetAnswer().Returns("Hola", "Adiós");
+
+        // Act
+        _studySessionsService.StartStudySessionAsync(cards1);
+        var scoreAfterFirst = _studySessionsService.Score;
+
+        _studySessionsService.StartStudySessionAsync(cards2);
+        var scoreAfterSecond = _studySessionsService.Score;
+
+        // Assert
+        Assert.Equal(1, scoreAfterFirst);
+        Assert.Equal(1, scoreAfterSecond);
     }
 
     [Fact]

--- a/Flashcards/DataAccess/Interfaces/ICardsRepository.cs
+++ b/Flashcards/DataAccess/Interfaces/ICardsRepository.cs
@@ -6,6 +6,7 @@ namespace Flashcards.DataAccess.Interfaces;
 public interface ICardsRepository
 {
     Task<Result> AddFlashcardAsync(int stackId, string front, string back);
+    Task<Result> AddMultipleChoiceCardAsync(int stackId, string question, List<string> choices, List<string> answers);
     Task<Result> DeleteCardAsync(int cardId);
     Task<Result> UpdateFlashcardAsync(int flashcardId, string front, string back);
     Task<Result<IEnumerable<BaseCard>>> GetAllCardsAsync();

--- a/Flashcards/DataAccess/Interfaces/ICardsRepository.cs
+++ b/Flashcards/DataAccess/Interfaces/ICardsRepository.cs
@@ -9,5 +9,6 @@ public interface ICardsRepository
     Task<Result> AddMultipleChoiceCardAsync(int stackId, string question, List<string> choices, List<string> answers);
     Task<Result> DeleteCardAsync(int cardId);
     Task<Result> UpdateFlashcardAsync(int flashcardId, string front, string back);
+    Task<Result> UpdateMultipleChoiceCardAsync(int cardId, string question, List<string> choices, List<string> answers);
     Task<Result<IEnumerable<BaseCard>>> GetAllCardsAsync();
 }

--- a/Flashcards/DataAccess/Interfaces/IStacksRepository.cs
+++ b/Flashcards/DataAccess/Interfaces/IStacksRepository.cs
@@ -8,6 +8,13 @@ public interface IStacksRepository
     Task<Result<Stack>> GetStackAsync(string name);
     Task<Result> DeleteStackAsync(int stackId);
     Task<Result> UpdateFlashcardInStackAsync(int flashcardId, int stackId, string front, string back);
+    Task<Result> UpdateMultipleChoiceCardAsync(
+        int flashcardId,
+        int stackId,
+        string question,
+        List<string> choices,
+        List<string> answer
+    );
     Task<Result<int>> GetCardsCountInStackAsync(int stackId);
     Task<Result> DeleteCardFromStackAsync(int flashcardId, int stackId);
     Task<Result<IEnumerable<BaseCard>>> GetCardsByStackIdAsync(int stackId);

--- a/Flashcards/DataAccess/Repositories/CardsRepository.cs
+++ b/Flashcards/DataAccess/Repositories/CardsRepository.cs
@@ -166,9 +166,9 @@ public class CardsRepository : ICardsRepository
         }
     }
 
-    public async Task<Result> UpdateFlashcardAsync(int flashcardId, string front, string back)
+    public async Task<Result> UpdateFlashcardAsync(int cardId, string front, string back)
     {
-        _logger.LogInformation("Updating flashcard {FlashcardId}.", flashcardId);
+        _logger.LogInformation("Updating flashcard {CardId}.", cardId);
         try
         {
             using (var connection = new SqlConnection(_defaultConnectionString))
@@ -179,20 +179,52 @@ public class CardsRepository : ICardsRepository
                 {
                     Front = front,
                     Back = back,
-                    Id = flashcardId
+                    Id = cardId
                 });
             }
-            _logger.LogInformation("Successfully updated flashcard {FlashcardId}.", flashcardId);
+            _logger.LogInformation("Successfully updated flashcard {CardId}.", cardId);
             return Result.Success();
         }
         catch (SqlException ex)
         {
-            _logger.LogError(ex, "SQL error while updating flashcard {FlashcardId}.", flashcardId);
+            _logger.LogError(ex, "SQL error while updating flashcard {CardId}.", cardId);
             return Result.Failure(CardsErrors.UpdateFailed);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Unexpected error while updating flashcard {FlashcardId}.", flashcardId);
+            _logger.LogError(ex, "Unexpected error while updating flashcard {CardId}.", cardId);
+            return Result.Failure(CardsErrors.UpdateFailed);
+        }
+    }
+
+    public async Task<Result> UpdateMultipleChoiceCardAsync(int cardId, string question, List<string> choices, List<string> answers)
+    {
+        _logger.LogInformation("Updating multiple choice card {CardId}.", cardId);
+        try
+        {
+            using (var connection = new SqlConnection(_defaultConnectionString))
+            {
+                string sql = SqlScripts.UpdateMultipleChoiceCard;
+
+                await connection.ExecuteAsync(sql, new
+                {
+                    Question = question,
+                    Choices = string.Join(";", choices),
+                    Answer = string.Join(";", answers),
+                    Id = cardId
+                });
+            }
+            _logger.LogInformation("Successfully updated multiple choice card {CardId}.", cardId);
+            return Result.Success();
+        }
+        catch (SqlException ex)
+        {
+            _logger.LogError(ex, "SQL error while updating multiple choice card {CardId}.", cardId);
+            return Result.Failure(CardsErrors.UpdateFailed);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unexpected error while updating multiple choice card {CardId}.", cardId);
             return Result.Failure(CardsErrors.UpdateFailed);
         }
     }

--- a/Flashcards/DataAccess/Repositories/CardsRepository.cs
+++ b/Flashcards/DataAccess/Repositories/CardsRepository.cs
@@ -51,6 +51,38 @@ public class CardsRepository : ICardsRepository
         }
     }
 
+    public async Task<Result> AddMultipleChoiceCardAsync(int stackId, string question, List<string> choices, List<string> answers)
+    {
+        _logger.LogInformation("Adding multiple choice card to stack {StackId}.", stackId);
+        try
+        {
+            using (var connection = new SqlConnection(_defaultConnectionString))
+            {
+                string sql = SqlScripts.AddMultipleChoiceCard;
+                await connection.ExecuteAsync(sql, new
+                {
+                    StackId = stackId,
+                    Question = question,
+                    Choices = string.Join(";", choices),
+                    Answer = string.Join(";", answers),
+                    CardType = CardType.MultipleChoice.ToString()
+                });
+                _logger.LogInformation("Successfully added multiple choice card to stack {StackId}.", stackId);
+                return Result.Success();
+            }
+        }
+        catch (SqlException ex)
+        {
+            _logger.LogError(ex, "SQL error while adding multiple choice card to stack {StackId}.", stackId);
+            return Result.Failure(CardsErrors.AddFailed);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unexpected error while adding multiple choice card to stack {StackId}.", stackId);
+            return Result.Failure(CardsErrors.AddFailed);
+        }
+    }
+
     public async Task<Result> DeleteCardAsync(int cardId)
     {
         _logger.LogInformation("Deleting card {CardId}.", cardId);

--- a/Flashcards/DataAccess/Repositories/StacksRepository.cs
+++ b/Flashcards/DataAccess/Repositories/StacksRepository.cs
@@ -123,27 +123,27 @@ public class StacksRepository : IStacksRepository
         }
     }
 
-    public async Task<Result> UpdateFlashcardInStackAsync(int flashcardId, int stackId, string front, string back)
+    public async Task<Result> UpdateFlashcardInStackAsync(int cardId, int stackId, string front, string back)
     {
-        _logger.LogInformation("Updating flashcard {FlashcardId} in stack {StackId}.", flashcardId, stackId);
+        _logger.LogInformation("Updating flashcard {CardId} in stack {StackId}.", cardId, stackId);
         try
         {
             using (var connection = new SqlConnection(_defaultConnectionString))
             {
                 string sql = SqlScripts.UpdateFlashcardInStack;
-                await connection.ExecuteAsync(sql, new { Front = front, Back = back, Id = flashcardId, StackId = stackId });
+                await connection.ExecuteAsync(sql, new { Front = front, Back = back, Id = cardId, StackId = stackId });
             }
-            _logger.LogInformation("Successfully updated flashcard {FlashcardId} in stack {StackId}.", flashcardId, stackId);
+            _logger.LogInformation("Successfully updated flashcard {CardId} in stack {StackId}.", cardId, stackId);
             return Result.Success();
         }
         catch (SqlException ex)
         {
-            _logger.LogError(ex, "SQL error while updating flashcard {FlashcardId} in stack {StackId}.", flashcardId, stackId);
+            _logger.LogError(ex, "SQL error while updating flashcard {CardId} in stack {StackId}.", cardId, stackId);
             return Result.Failure(StacksErrors.UpdateFailed);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Unexpected error while updating flashcard {FlashcardId} in stack {StackId}.", flashcardId, stackId);
+            _logger.LogError(ex, "Unexpected error while updating flashcard {CardId} in stack {StackId}.", cardId, stackId);
             return Result.Failure(StacksErrors.UpdateFailed);
         }
     }
@@ -270,6 +270,42 @@ public class StacksRepository : IStacksRepository
         {
             _logger.LogError(ex, "Unexpected error while getting cards count in stack {StackId}.", stackId);
             return Result.Failure<int>(StacksErrors.GetCardsCountFailed);
+        }
+    }
+
+    public async Task<Result> UpdateMultipleChoiceCardAsync
+        (
+        int cardId,
+        int stackId, string question, List<string> choices, List<string> answers
+        )
+    {
+        _logger.LogInformation("Updating multiple choice card {CardId} in stack {StackId}.", cardId, stackId);
+        try
+        {
+            using (var connection = new SqlConnection(_defaultConnectionString))
+            {
+                string sql = SqlScripts.UpdateMultipleChoiceCardInStack;
+                await connection.ExecuteAsync(sql, new
+                {
+                    Question = question,
+                    Choices = string.Join(";", choices),
+                    Answer = string.Join(";", answers),
+                    Id = cardId,
+                    StackId = stackId
+                });
+            }
+            _logger.LogInformation("Successfully updated multiple choice card {CardId} in stack {StackId}.", cardId, stackId);
+            return Result.Success();
+        }
+        catch (SqlException ex)
+        {
+            _logger.LogError(ex, "SQL error while updating multiple choice card {CardId} in stack {StackId}.", cardId, stackId);
+            return Result.Failure(StacksErrors.UpdateFailed);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unexpected error while updating multiple choice card {CardId} in stack {StackId}.", cardId, stackId);
+            return Result.Failure(StacksErrors.UpdateFailed);
         }
     }
 }

--- a/Flashcards/Helpers/DataVisualizer.cs
+++ b/Flashcards/Helpers/DataVisualizer.cs
@@ -162,4 +162,14 @@ public static class DataVisualizer
 
         AnsiConsole.Write(table);
     }
+
+    public static void ShowMultipleChoiceCard(string question)
+    {
+        var questionPanel = new Panel(question)
+            .Header("Question")
+            .Border(BoxBorder.Rounded)
+            .Padding(2, 2, 2, 2);
+
+        AnsiConsole.Write(new Align(questionPanel, HorizontalAlignment.Center));
+    }
 }

--- a/Flashcards/Helpers/DataVisualizer.cs
+++ b/Flashcards/Helpers/DataVisualizer.cs
@@ -28,10 +28,10 @@ public static class DataVisualizer
         {
             string details = card switch
             {
-                FlashcardDTO f => $"[green]Front:[/] {f.Front}\n[blue]Back:[/] {f.Back}",
-                ClozeCardDTO c => $"[green]Cloze:[/] {c.ClozeText}",
-                FillInCardDTO fi => $"[green]FillIn:[/] {fi.FillInText}\n[blue]Answers:[/] {string.Join(", ", fi.Answer)}",
-                MultipleChoiceCardDTO mc => $"[green]Question:[/] {mc.Question}\n[blue]Choices:[/] {string.Join(", ", mc.Choices)}\n[magenta]Answer:[/] {mc.Answer}",
+                FlashcardDTO f => $"[green]Front:[/] {Markup.Escape(f.Front)}\n[blue]Back:[/] {Markup.Escape(f.Back)}",
+                ClozeCardDTO c => $"[green]Cloze:[/] {Markup.Escape(c.ClozeText)}",
+                FillInCardDTO fi => $"[green]FillIn:[/] {Markup.Escape(fi.FillInText)}\n[blue]Answers:[/] {Markup.Escape(string.Join(", ", fi.Answer))}",
+                MultipleChoiceCardDTO mc => $"[green]Question:[/] {Markup.Escape(mc.Question)}\n[blue]Choices:[/] {Markup.Escape(string.Join(", ", mc.Choices))}\n[magenta]Answer:[/] {Markup.Escape(string.Join(", ", mc.Answer))}",
                 _ => "[red]Unknown card type[/]"
             };
 

--- a/Flashcards/Helpers/Mapper.cs
+++ b/Flashcards/Helpers/Mapper.cs
@@ -44,7 +44,7 @@ public static class Mapper
             Id = fillInCard.Id,
             CardType = fillInCard.CardType,
             FillInText = fillInCard.FillInText ?? string.Empty,
-            Answer = fillInCard.Answer ?? new List<string>(),
+            Answer = fillInCard.Answer != null ? fillInCard.Answer.Split(';').ToList() : new()
         };
     }
 
@@ -55,8 +55,8 @@ public static class Mapper
             Id = multipleChoiceCard.Id,
             CardType = multipleChoiceCard.CardType,
             Question = multipleChoiceCard.Question ?? string.Empty,
-            Choices = multipleChoiceCard.Choices ?? new List<string>(),
-            Answer = multipleChoiceCard.Answer ?? string.Empty,
+            Choices = multipleChoiceCard.Choices != null ? multipleChoiceCard.Choices.Split(';').ToList() : new(),
+            Answer = multipleChoiceCard.Answer != null ? multipleChoiceCard.Answer.Split(';').ToList() : new(),
         };
     }
 

--- a/Flashcards/Models/Flashcard.cs
+++ b/Flashcards/Models/Flashcard.cs
@@ -23,14 +23,14 @@ public class ClozeCard : BaseCard
 public class FillInCard : BaseCard
 {
     public string? FillInText { get; set; }
-    public List<string>? Answer { get; set; }
+    public string? Answer { get; set; }
     public FillInCard() => CardType = CardType.FillIn;
 }
 
 public class MultipleChoiceCard : BaseCard
 {
     public string? Question { get; set; }
-    public List<string>? Choices { get; set; }
+    public string? Choices { get; set; }
     public string? Answer { get; set; }
     public MultipleChoiceCard() => CardType = CardType.MultipleChoice;
 }
@@ -62,7 +62,7 @@ public record class MultipleChoiceCardDTO : BaseCardDTO
 {
     public string Question { get; init; } = string.Empty;
     public List<string> Choices { get; init; } = new();
-    public string Answer { get; init; } = string.Empty;
+    public List<string> Answer { get; init; } = new();
 }
 
 public enum CardType

--- a/Flashcards/Services/CardStrategies/MultipleChoiceCardStrategy.cs
+++ b/Flashcards/Services/CardStrategies/MultipleChoiceCardStrategy.cs
@@ -1,0 +1,82 @@
+﻿using Flashcards.DataAccess.Interfaces;
+using Flashcards.Services.Interfaces;
+using Flashcards.Utils;
+
+namespace Flashcards.Services.CardStrategies;
+public class MultipleChoiceCardStrategy : ICardStrategy
+{
+    private readonly ICardsRepository _cardsRepository;
+    private readonly IUserInteractionService _userInteractionService;
+    private readonly IStacksRepository? _stacksRepository;
+
+    public MultipleChoiceCardStrategy(ICardsRepository cardsRepository, IUserInteractionService userInteractionService)
+    {
+        _cardsRepository = cardsRepository;
+        _userInteractionService = userInteractionService;
+    }
+
+    public MultipleChoiceCardStrategy(ICardsRepository cardsRepository, IUserInteractionService userInteractionService, IStacksRepository stacksRepository)
+    {
+        _cardsRepository = cardsRepository;
+        _userInteractionService = userInteractionService;
+        _stacksRepository = stacksRepository;
+    }
+
+    public async Task<Result> AddCardAsync(int stackId)
+    {
+        var question = _userInteractionService.GetMultipleChoiceQuestion();
+        var numberOfChoices = _userInteractionService.GetNumberOfChoices();
+        var choices = _userInteractionService.GetMultipleChoiceChoices(numberOfChoices);
+        var answer = _userInteractionService.GetMultipleChoiceAnswers(choices);
+
+        var addResult = await _cardsRepository.AddMultipleChoiceCardAsync(
+            stackId,
+            question,
+            choices,
+            answer
+        );
+
+        if (addResult.IsFailure) return Result.Failure(addResult.Error);
+
+        return Result.Success();
+    }
+
+    public async Task<Result> UpdateCardAsync(int cardId)
+    {
+        var question = _userInteractionService.GetMultipleChoiceQuestion();
+        var numberOfChoices = _userInteractionService.GetNumberOfChoices();
+        var choices = _userInteractionService.GetMultipleChoiceChoices(numberOfChoices);
+        var answer = _userInteractionService.GetMultipleChoiceAnswers(choices);
+
+        var updateResult = await _cardsRepository.UpdateMultipleChoiceCardAsync(
+            cardId,
+            question,
+            choices,
+            answer
+        );
+
+        if (updateResult.IsFailure) return Result.Failure(updateResult.Error);
+
+        return Result.Success();
+    }
+
+    public async Task<Result> UpdateCardInStackAsync(int cardId, int stackId)
+    {
+        var question = _userInteractionService.GetMultipleChoiceQuestion();
+        var numberOfChoices = _userInteractionService.GetNumberOfChoices();
+        var choices = _userInteractionService.GetMultipleChoiceChoices(numberOfChoices);
+        var answer = _userInteractionService.GetMultipleChoiceAnswers(choices);
+
+        var updateResult = await _stacksRepository.UpdateMultipleChoiceCardAsync(
+            cardId,
+            stackId,
+            question,
+            choices,
+            answer
+        );
+
+        if (updateResult.IsFailure) return Result.Failure(updateResult.Error);
+
+        return Result.Success();
+    }
+}

--- a/Flashcards/Services/CardsService.cs
+++ b/Flashcards/Services/CardsService.cs
@@ -59,6 +59,7 @@ public class CardsService : ICardsService
         ICardStrategy strategy = chosenCardType switch
         {
             CardType.Flashcard => new FlashcardStrategy(_cardsRepository, _userInteractionService),
+            CardType.MultipleChoice => new MultipleChoiceCardStrategy(_cardsRepository, _userInteractionService),
             _ => throw new ArgumentOutOfRangeException(nameof(chosenCardType), "Invalid card type selected.")
         };
 
@@ -118,6 +119,9 @@ public class CardsService : ICardsService
                 case Flashcard flashcard:
                     cardDtos.Add(Mapper.ToFlashcardDTO(flashcard));
                     break;
+                case MultipleChoiceCard multipleChoiceCard:
+                    cardDtos.Add(Mapper.ToMultipleChoiceCardDTO(multipleChoiceCard));
+                    break;
                 default:
                     _logger.LogWarning("Unknown card type encountered in GetAllCardsAsync.");
                     return Result.Failure<List<BaseCardDTO>>(CardsErrors.GetAllFailed);
@@ -145,6 +149,7 @@ public class CardsService : ICardsService
         ICardStrategy strategy = chosenCard.CardType switch
         {
             CardType.Flashcard => new FlashcardStrategy(_cardsRepository, _userInteractionService),
+            CardType.MultipleChoice => new MultipleChoiceCardStrategy(_cardsRepository, _userInteractionService),
             _ => throw new ArgumentOutOfRangeException(nameof(chosenCard.CardType), "Invalid card type selected.")
         };
 

--- a/Flashcards/Services/Interfaces/IUserInteractionService.cs
+++ b/Flashcards/Services/Interfaces/IUserInteractionService.cs
@@ -8,6 +8,10 @@ public interface IUserInteractionService
     int GetId();
     string GetFlashcardFront();
     string GetFlashcardBack();
+    string GetMultipleChoiceQuestion();
+    List<string> GetMultipleChoiceChoices(int numberOfChoices);
+    int GetNumberOfChoices();
+    List<string> GetMultipleChoiceAnswers(List<string> choices);
     string GetStackName();
     string GetAnswer();
     string GetYear();

--- a/Flashcards/Services/StacksService.cs
+++ b/Flashcards/Services/StacksService.cs
@@ -73,6 +73,7 @@ public class StacksService : IStacksService
         ICardStrategy strategy = chosenCardType switch
         {
             CardType.Flashcard => new FlashcardStrategy(_cardsRepository, _userInteractionService),
+            CardType.MultipleChoice => new MultipleChoiceCardStrategy(_cardsRepository, _userInteractionService),
             _ => throw new ArgumentOutOfRangeException(nameof(chosenCardType), "Invalid card type selected.")
         };
 
@@ -157,6 +158,7 @@ public class StacksService : IStacksService
         ICardStrategy strategy = chosenCard.CardType switch
         {
             CardType.Flashcard => new FlashcardStrategy(_cardsRepository, _userInteractionService, _stacksRepository),
+            CardType.MultipleChoice => new MultipleChoiceCardStrategy(_cardsRepository, _userInteractionService, _stacksRepository),
             _ => throw new ArgumentOutOfRangeException(nameof(chosenCard.CardType), "Invalid card type selected.")
         };
 
@@ -192,6 +194,9 @@ public class StacksService : IStacksService
             {
                 case Flashcard flashcard:
                     cardDtos.Add(Mapper.ToFlashcardDTO(flashcard));
+                    break;
+                case MultipleChoiceCard multipleChoiceCard:
+                    cardDtos.Add(Mapper.ToMultipleChoiceCardDTO(multipleChoiceCard));
                     break;
                 default:
                     _logger.LogWarning("Unknown card type encountered in GetCardsByStackIdAsync.");

--- a/Flashcards/Services/UserInteractionService.cs
+++ b/Flashcards/Services/UserInteractionService.cs
@@ -124,4 +124,48 @@ public class UserInteractionService : IUserInteractionService
         AnsiConsole.MarkupLine("Press Enter to continue...");
         Console.ReadLine();
     }
+
+    public string GetMultipleChoiceQuestion()
+    {
+        return AnsiConsole.Prompt(
+             new TextPrompt<string>("Enter the question for the multiple choice card:")
+             );
+    }
+
+    public List<string> GetMultipleChoiceChoices(int numberOfChoices)
+    {
+        var choices = new List<string>();
+
+        for (int i = 0; i < numberOfChoices; i++)
+        {
+            string choice = AnsiConsole.Prompt(
+                new TextPrompt<string>($"Enter choice {i + 1}:")
+            );
+            choices.Add(choice);
+        }
+
+        return choices;
+    }
+
+    public int GetNumberOfChoices()
+    {
+        return AnsiConsole.Prompt(
+            new TextPrompt<int>("Enter the number of choices for the multiple choice card:")
+                .ValidationErrorMessage("[red]That is not a valid number of choices[/]")
+                .Validate(Validation.IsPositiveNumber)
+        );
+    }
+
+    public List<string> GetMultipleChoiceAnswers(List<string> choices)
+    {
+        return AnsiConsole.Prompt(
+            new MultiSelectionPrompt<string>()
+                .Title("Select the correct answers:")
+                .MoreChoicesText("[grey](Move up and down to reveal more choices)[/]")
+                .InstructionsText("[grey](Press [blue]space[/] to toggle a choice, [green]enter[/] to accept)[/]")
+                .PageSize(10)
+                .AddChoices(choices)
+                .UseConverter(choice => choice)
+        );
+    }
 }

--- a/Flashcards/SqlScripts.Designer.cs
+++ b/Flashcards/SqlScripts.Designer.cs
@@ -72,6 +72,17 @@ namespace Flashcards {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to INSERT INTO Cards (StackId, Question, Choices, Answer, CardType)
+        ///VALUES
+        ///(@StackId, @Question, @Choices, @Answer, @CardType).
+        /// </summary>
+        internal static string AddMultipleChoiceCard {
+            get {
+                return ResourceManager.GetString("AddMultipleChoiceCard", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to INSERT INTO Stacks (Name)
         ///VALUES
         ///(@Name).
@@ -353,6 +364,28 @@ namespace Flashcards {
         internal static string UpdateFlashcardInStack {
             get {
                 return ResourceManager.GetString("UpdateFlashcardInStack", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to UPDATE Cards
+        ///SET Question = @Question, Choices = @Choices, Answer = @Answer
+        ///WHERE Id = @Id.
+        /// </summary>
+        internal static string UpdateMultipleChoiceCard {
+            get {
+                return ResourceManager.GetString("UpdateMultipleChoiceCard", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to UPDATE Cards
+        ///SET Question = @Question, Choices = @Choices, Answer = @Answer
+        ///WHERE Id = @Id AND StackId = @StackId.
+        /// </summary>
+        internal static string UpdateMultipleChoiceCardInStack {
+            get {
+                return ResourceManager.GetString("UpdateMultipleChoiceCardInStack", resourceCulture);
             }
         }
     }

--- a/Flashcards/SqlScripts.Designer.cs
+++ b/Flashcards/SqlScripts.Designer.cs
@@ -307,7 +307,9 @@ namespace Flashcards {
         ///	(2, &apos;Danke&apos;, &apos;Thank you&apos;, &apos;Flashcard&apos;),
         ///	(3, &apos;Dzień dobry&apos;, &apos;Good morning&apos;, &apos;Flashcard&apos;),
         ///	(3, &apos;Do widzenia&apos;, &apos;Goodbye&apos;, &apos;Flashcard&apos;),
-        ///	(3, &apos;Proszę&apos;, &apos;Please&apos;, &apos;Flashcard&apos;);.
+        ///	(3, &apos;Proszę&apos;, &apos;Please&apos;, &apos;Flashcard&apos;);
+        ///
+        ///	INSERT INTO Cards (StackId, Question, Choice [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string SeedCards {
             get {

--- a/Flashcards/SqlScripts.resx
+++ b/Flashcards/SqlScripts.resx
@@ -121,6 +121,9 @@
   <data name="AddFlashcard" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>SqlScripts\AddFlashcard.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;windows-1250</value>
   </data>
+  <data name="AddMultipleChoiceCard" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>SqlScripts\AddMultipleChoiceCard.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;windows-1250</value>
+  </data>
   <data name="AddStack" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>SqlScripts\AddStack.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;windows-1250</value>
   </data>
@@ -183,5 +186,11 @@
   </data>
   <data name="UpdateFlashcardInStack" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>SqlScripts\UpdateFlashcardInStack.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;windows-1250</value>
+  </data>
+  <data name="UpdateMultipleChoiceCard" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>SqlScripts\UpdateMultipleChoiceCard.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;windows-1250</value>
+  </data>
+  <data name="UpdateMultipleChoiceCardInStack" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>SqlScripts\UpdateMultipleChoiceCardInStack.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;windows-1250</value>
   </data>
 </root>

--- a/Flashcards/SqlScripts/AddMultipleChoiceCard.sql
+++ b/Flashcards/SqlScripts/AddMultipleChoiceCard.sql
@@ -1,0 +1,3 @@
+INSERT INTO Cards (StackId, Question, Choices, Answer, CardType)
+VALUES
+(@StackId, @Question, @Choices, @Answer, @CardType)

--- a/Flashcards/SqlScripts/SeedCards.sql
+++ b/Flashcards/SqlScripts/SeedCards.sql
@@ -8,3 +8,8 @@
 	(3, 'Dzień dobry', 'Good morning', 'Flashcard'),
 	(3, 'Do widzenia', 'Goodbye', 'Flashcard'),
 	(3, 'Proszę', 'Please', 'Flashcard');
+
+	INSERT INTO Cards (StackId, Question, Choices, Answer, CardType) VALUES
+	(3, 'Jakie jest największe miasto w Polsce?', 'Kraków;Warszawa;Gdańsk;Wrocław', 'Warszawa', 'MultipleChoice'),
+	(3, 'Które z tych są polskimi rzekami?', 'Wisła;Odra;Ren;Dunaj;Warta', 'Wisła;Odra;Warta', 'MultipleChoice'),
+	(3, 'Ile województw ma Polska?', 'Czternaście;Piętnaście;Szesnaście;Siedemnaście', 'Szesnaście', 'MultipleChoice');

--- a/Flashcards/SqlScripts/UpdateMultipleChoiceCard.sql
+++ b/Flashcards/SqlScripts/UpdateMultipleChoiceCard.sql
@@ -1,0 +1,3 @@
+UPDATE Cards
+SET Question = @Question, Choices = @Choices, Answer = @Answer
+WHERE Id = @Id

--- a/Flashcards/SqlScripts/UpdateMultipleChoiceCardInStack.sql
+++ b/Flashcards/SqlScripts/UpdateMultipleChoiceCardInStack.sql
@@ -1,0 +1,3 @@
+UPDATE Cards
+SET Question = @Question, Choices = @Choices, Answer = @Answer
+WHERE Id = @Id AND StackId = @StackId


### PR DESCRIPTION
#### Summary
This pull request introduces functionality for adding and updating multiple choice cards, along with necessary user interaction and database handling improvements.

#### Changes
- `CardsServiceIntegrationTests` and `StacksServiceIntegrationTests`: Added integration tests for multiple choice card operations.
- `CardsServiceTests` and `StackServiceTests`: Added unit tests for multiple choice card operations.
- `ICardsRepository` and `IStacksRepository`: Implemented methods for adding and updating multiple choice cards.
- `CardsRepository` and `StacksRepository`: Updated to handle multiple choice card database operations.
- `UserInteractionService`: Modified to include methods for obtaining multiple choice questions, choices, and answers.
- `StudySessionsService`: Enhanced to support multiple choice cards during study sessions, including score calculation and answer validation.
- `CardsService` and `StacksService`: Delegate multiple choice card operations to `MultipleChoiceCardStrategy`.
- `SqlScripts`: Added sql files with queries executing multiple choice cards operations.
- `DataVisualizer`: Added displaying multiple choice card question.
- Adjusted properties in card models and mapping to data transfer objects.
