### PR TITLE
feat: support cloze deletion card database operations

### DIFF
--- a/Flashcards/DataAccess/Interfaces/ICardsRepository.cs
+++ b/Flashcards/DataAccess/Interfaces/ICardsRepository.cs
@@ -1,4 +1,4 @@
-﻿using Flashcards.Models;
+using Flashcards.Models;
 using Flashcards.Utils;
 
 namespace Flashcards.DataAccess.Interfaces;
@@ -6,9 +6,11 @@ namespace Flashcards.DataAccess.Interfaces;
 public interface ICardsRepository
 {
     Task<Result> AddFlashcardAsync(int stackId, string front, string back);
+    Task<Result> AddClozeCardAsync(int stackId, string clozeText);
     Task<Result> AddMultipleChoiceCardAsync(int stackId, string question, List<string> choices, List<string> answers);
     Task<Result> DeleteCardAsync(int cardId);
     Task<Result> UpdateFlashcardAsync(int flashcardId, string front, string back);
+    Task<Result> UpdateClozeCardAsync(int clozeCardId, string clozeText);
     Task<Result> UpdateMultipleChoiceCardAsync(int multipleChoiceCardId, string question, List<string> choices, List<string> answers);
     Task<Result<IEnumerable<BaseCard>>> GetAllCardsAsync();
 }

--- a/Flashcards/DataAccess/Interfaces/IStacksRepository.cs
+++ b/Flashcards/DataAccess/Interfaces/IStacksRepository.cs
@@ -1,4 +1,4 @@
-﻿using Flashcards.Models;
+using Flashcards.Models;
 using Flashcards.Utils;
 
 namespace Flashcards.DataAccess.Interfaces;
@@ -15,6 +15,7 @@ public interface IStacksRepository
         List<string> choices,
         List<string> answers
     );
+    Task<Result> UpdateClozeCardInStackAsync(int clozeCardId, int stackId, string clozeText);
     Task<Result<int>> GetCardsCountInStackAsync(int stackId);
     Task<Result> DeleteCardFromStackAsync(int cardId, int stackId);
     Task<Result<IEnumerable<BaseCard>>> GetCardsByStackIdAsync(int stackId);

--- a/Flashcards/DataAccess/Repositories/StacksRepository.cs
+++ b/Flashcards/DataAccess/Repositories/StacksRepository.cs
@@ -1,4 +1,4 @@
-﻿using Dapper;
+using Dapper;
 
 using Flashcards.DataAccess.Interfaces;
 using Flashcards.Models;
@@ -307,6 +307,38 @@ public class StacksRepository : IStacksRepository
         catch (Exception ex)
         {
             _logger.LogError(ex, "Unexpected error while updating multiple choice card {CardId} in stack {StackId}.", multipleChoiceCardId, stackId);
+            return Result.Failure(StacksErrors.UpdateFailed);
+        }
+    }
+
+    public async Task<Result> UpdateClozeCardInStackAsync(int clozeCardId, int stackId, string clozeText)
+    {
+        _logger.LogInformation("Updating cloze card {CardId} in stack {StackId}.", clozeCardId, stackId);
+        try
+        {
+            using (var connection = new SqlConnection(_defaultConnectionString))
+            {
+                string sql = SqlScripts.UpdateClozeCardInStack;
+
+                await connection.ExecuteAsync(sql, new
+                {
+                    ClozeText = clozeText,
+                    Id = clozeCardId,
+                    StackId = stackId
+                });
+
+                _logger.LogInformation("Successfully updated cloze card {CardId} in stack {StackId}.", clozeCardId, stackId);
+                return Result.Success();
+            }
+        }
+        catch (SqlException ex)
+        {
+            _logger.LogError(ex, "SQL error while updating cloze card {CardId} in stack {StackId}.", clozeCardId, stackId);
+            return Result.Failure(StacksErrors.UpdateFailed);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unexpected error while updating cloze card {CardId} in stack {StackId}.", clozeCardId, stackId);
             return Result.Failure(StacksErrors.UpdateFailed);
         }
     }

--- a/Flashcards/SqlScripts.Designer.cs
+++ b/Flashcards/SqlScripts.Designer.cs
@@ -61,6 +61,17 @@ namespace Flashcards {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to INSERT INTO Cards (StackId, ClozeText, CardType)
+        ///VALUES
+        ///(@StackId, @ClozeText, @CardType).
+        /// </summary>
+        internal static string AddClozeCard {
+            get {
+                return ResourceManager.GetString("AddClozeCard", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to INSERT INTO Cards (StackId, Front, Back, CardType)
         ///VALUES
         ///(@StackId, @Front, @Back, @CardType).
@@ -344,6 +355,28 @@ namespace Flashcards {
         internal static string StackExistsWithName {
             get {
                 return ResourceManager.GetString("StackExistsWithName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to UPDATE Cards
+        ///SET ClozeText = @ClozeText
+        ///WHERE Id = @Id.
+        /// </summary>
+        internal static string UpdateClozeCard {
+            get {
+                return ResourceManager.GetString("UpdateClozeCard", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to UPDATE Cards
+        ///SET ClozeText = @ClozeText
+        ///WHERE Id = @Id AND StackId = @StackId.
+        /// </summary>
+        internal static string UpdateClozeCardInStack {
+            get {
+                return ResourceManager.GetString("UpdateClozeCardInStack", resourceCulture);
             }
         }
         

--- a/Flashcards/SqlScripts.resx
+++ b/Flashcards/SqlScripts.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -118,6 +118,9 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="AddClozeCard" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>SqlScripts\AddClozeCard.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;windows-1250</value>
+  </data>
   <data name="AddFlashcard" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>SqlScripts\AddFlashcard.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;windows-1250</value>
   </data>
@@ -180,6 +183,12 @@
   </data>
   <data name="StackExistsWithName" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>SqlScripts\StackExistsWithName.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;windows-1250</value>
+  </data>
+  <data name="UpdateClozeCard" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>SqlScripts\UpdateClozeCard.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;windows-1250</value>
+  </data>
+  <data name="UpdateClozeCardInStack" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>SqlScripts\UpdateClozeCardInStack.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;windows-1250</value>
   </data>
   <data name="UpdateFlashcard" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>SqlScripts\UpdateFlashcard.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;windows-1250</value>

--- a/Flashcards/SqlScripts/AddClozeCard.sql
+++ b/Flashcards/SqlScripts/AddClozeCard.sql
@@ -1,0 +1,3 @@
+INSERT INTO Cards (StackId, ClozeText, CardType)
+VALUES
+(@StackId, @ClozeText, @CardType)

--- a/Flashcards/SqlScripts/SeedCards.sql
+++ b/Flashcards/SqlScripts/SeedCards.sql
@@ -1,4 +1,4 @@
-﻿INSERT INTO Cards (StackId, Front, Back, CardType) VALUES
+INSERT INTO Cards (StackId, Front, Back, CardType) VALUES
 	(1, 'Hola', 'Hello', 'Flashcard'),
 	(1, '¿Cómo estás?', 'How are you?', 'Flashcard'),
 	(1, 'Gracias', 'Thank you', 'Flashcard'),
@@ -9,7 +9,13 @@
 	(3, 'Do widzenia', 'Goodbye', 'Flashcard'),
 	(3, 'Proszę', 'Please', 'Flashcard');
 
-	INSERT INTO Cards (StackId, Question, Choices, Answer, CardType) VALUES
-	(3, 'Jakie jest największe miasto w Polsce?', 'Kraków;Warszawa;Gdańsk;Wrocław', 'Warszawa', 'MultipleChoice'),
+INSERT INTO Cards (StackId, Question, Choices, Answer, CardType) VALUES
+    (3, 'Jakie jest największe miasto w Polsce?', 'Kraków;Warszawa;Gdańsk;Wrocław', 'Warszawa', 'MultipleChoice'),
 	(3, 'Które z tych są polskimi rzekami?', 'Wisła;Odra;Ren;Dunaj;Warta', 'Wisła;Odra;Warta', 'MultipleChoice'),
 	(3, 'Ile województw ma Polska?', 'Czternaście;Piętnaście;Szesnaście;Siedemnaście', 'Szesnaście', 'MultipleChoice');
+
+INSERT INTO Cards (StackId, ClozeText, CardType) VALUES
+    (2, 'Guten {{c1::Morgen}}!', 'Cloze'),
+    (2, 'Ich {{c1::heiße}} Anna.', 'Cloze'),
+    (2, 'Wie {{c1::geht}} es {{c2::dir}}?', 'Cloze'),
+    (2, 'Ich komme aus {{c1::Deutschland}}.', 'Cloze');

--- a/Flashcards/SqlScripts/UpdateClozeCard.sql
+++ b/Flashcards/SqlScripts/UpdateClozeCard.sql
@@ -1,0 +1,3 @@
+UPDATE Cards
+SET ClozeText = @ClozeText
+WHERE Id = @Id

--- a/Flashcards/SqlScripts/UpdateClozeCardInStack.sql
+++ b/Flashcards/SqlScripts/UpdateClozeCardInStack.sql
@@ -1,0 +1,3 @@
+UPDATE Cards
+SET ClozeText = @ClozeText
+WHERE Id = @Id AND StackId = @StackId


### PR DESCRIPTION
#### Summary
This pull request introduces methods for managing cloze cards in the card and stack repositories, along with necessary SQL scripts for database operations.

#### Changes
- `ICardsRepository`: Added `AddClozeCardAsync` and `UpdateClozeCardAsync` methods.
- `IStacksRepository`: Introduced `UpdateClozeCardInStackAsync` method.
- `CardsRepository`: Implemented methods for adding and updating cloze cards with logging and error handling.
- `StacksRepository`: Implemented `UpdateClozeCardInStackAsync` with logging and error handling.
- New SQL scripts created for adding and updating cloze cards, and initial data for cloze cards added to `SeedCards.sql`.
