### PR TITLE
feat: support cloze deletion cards during study sessions

### DIFF
--- a/Flashcards/Services/StudySessionsService.cs
+++ b/Flashcards/Services/StudySessionsService.cs
@@ -1,4 +1,6 @@
-﻿using Flashcards.DataAccess.Interfaces;
+using System.Text.RegularExpressions;
+
+using Flashcards.DataAccess.Interfaces;
 using Flashcards.Helpers;
 using Flashcards.Models;
 using Flashcards.Services.Interfaces;
@@ -69,6 +71,87 @@ public class StudySessionsService : IStudySessionsService
                         AnsiConsole.MarkupLine("Your answer was wrong.");
                         AnsiConsole.MarkupLine($"The correct answer was {string.Join(',', multipleChoiceCard.Answer)}.");
                         _logger.LogInformation("Incorrect answer for card ID {CardId}.", multipleChoiceCard.Id);
+                    }
+                    break;
+                case ClozeCardDto clozeCard:
+                    var clozePattern = @"\{\{c\d+::(.*?)\}\}";
+                    var matches = Regex.Matches(clozeCard.ClozeText, clozePattern);
+
+                    string displayText = clozeCard.ClozeText;
+                    foreach (var clozeTag in from Match match in matches
+                                             let clozeTag = match.Value
+                                             select clozeTag)
+                    {
+                        displayText = displayText.Replace(clozeTag, "[bold underline]_____[/]");
+                    }
+
+                    AnsiConsole.MarkupLine("Fill in the blanks for the following sentence:");
+                    AnsiConsole.MarkupLine(displayText);
+
+                    List<string> correctAnswers = new();
+                    List<string> userClozeCardAnswers = new();
+                    int clozeIndex = 1;
+
+                    foreach (Match match in matches)
+                    {
+                        string hiddenText = match.Groups[1].Value;
+                        correctAnswers.Add(hiddenText);
+
+                        string prompt = $"Fill in the blank for cloze {clozeIndex}: ";
+                        AnsiConsole.MarkupLine(prompt);
+                        string userClozeCardAnswer = _userInteractionService.GetAnswer();
+                        userClozeCardAnswers.Add(userClozeCardAnswer);
+                        clozeIndex++;
+                    }
+
+                    string userFilledText = clozeCard.ClozeText;
+                    clozeIndex = 0;
+                    foreach (var (clozeTag, replacement) in from Match match in matches
+                                                            let clozeTag = match.Value
+                                                            let replacement = $"[bold yellow]{userClozeCardAnswers[clozeIndex]}[/]"
+                                                            select (clozeTag, replacement))
+                    {
+                        userFilledText = userFilledText.Replace(clozeTag, replacement);
+                        clozeIndex++;
+                    }
+
+                    AnsiConsole.MarkupLine("Your completed sentence:");
+                    AnsiConsole.MarkupLine(userFilledText);
+
+                    string correctFilledText = clozeCard.ClozeText;
+                    clozeIndex = 0;
+                    foreach (var (clozeTag, replacement) in from Match match in matches
+                                                            let clozeTag = match.Value
+                                                            let replacement = $"[bold green]{correctAnswers[clozeIndex]}[/]"
+                                                            select (clozeTag, replacement))
+                    {
+                        correctFilledText = correctFilledText.Replace(clozeTag, replacement);
+                        clozeIndex++;
+                    }
+
+                    AnsiConsole.MarkupLine("Correct sentence:");
+                    AnsiConsole.MarkupLine(correctFilledText);
+
+                    bool allCorrect = true;
+                    for (int i = 0; i < correctAnswers.Count; i++)
+                    {
+                        if (!string.Equals(userClozeCardAnswers[i], correctAnswers[i], StringComparison.OrdinalIgnoreCase))
+                        {
+                            allCorrect = false;
+                            break;
+                        }
+                    }
+
+                    if (allCorrect)
+                    {
+                        AnsiConsole.MarkupLine("Your answers are correct!");
+                        Score++;
+                        _logger.LogInformation("Correct cloze answers for card ID {CardId}.", clozeCard.Id);
+                    }
+                    else
+                    {
+                        AnsiConsole.MarkupLine("Your answers were wrong.");
+                        _logger.LogInformation("Incorrect cloze answers for card ID {CardId}.", clozeCard.Id);
                     }
                     break;
             }

--- a/Flashcards/Services/UserInteractionService.cs
+++ b/Flashcards/Services/UserInteractionService.cs
@@ -42,7 +42,7 @@ public class UserInteractionService : IUserInteractionService
     public string GetAnswer()
     {
         return AnsiConsole.Prompt(
-            new TextPrompt<string>("Enter your answer to this card")
+            new TextPrompt<string>("Enter your answer: ")
             );
     }
 


### PR DESCRIPTION
#### Summary
This pull request introduces functionality for handling cloze cards in the `StudySessionsService.cs`, allowing users to fill in blanks and receive feedback on their answers. It also updates the prompt text in `UserInteractionService.cs` for improved clarity.

#### Changes
- `StudySessionsService.cs`: Added regex matching for cloze tags, user prompts for filling in blanks, and feedback on answers.
- `UserInteractionService.cs`: Modified prompt text for user input to enhance clarity.
