### PR TITLE
feat: prepare database for spaced repetition

### DIFF
--- a/Flashcards/SqlScripts.Designer.cs
+++ b/Flashcards/SqlScripts.Designer.cs
@@ -309,18 +309,14 @@ namespace Flashcards {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to INSERT INTO Cards (StackId, Front, Back, CardType) VALUES
-        ///	(1, &apos;Hola&apos;, &apos;Hello&apos;, &apos;Flashcard&apos;),
-        ///	(1, &apos;¿Cómo estás?&apos;, &apos;How are you?&apos;, &apos;Flashcard&apos;),
-        ///	(1, &apos;Gracias&apos;, &apos;Thank you&apos;, &apos;Flashcard&apos;),
-        ///	(2, &apos;Hallo&apos;, &apos;Hello&apos;, &apos;Flashcard&apos;),
-        ///	(2, &apos;Wie geht es dir?&apos;, &apos;How are you?&apos;, &apos;Flashcard&apos;),
-        ///	(2, &apos;Danke&apos;, &apos;Thank you&apos;, &apos;Flashcard&apos;),
-        ///	(3, &apos;Dzień dobry&apos;, &apos;Good morning&apos;, &apos;Flashcard&apos;),
-        ///	(3, &apos;Do widzenia&apos;, &apos;Goodbye&apos;, &apos;Flashcard&apos;),
-        ///	(3, &apos;Proszę&apos;, &apos;Please&apos;, &apos;Flashcard&apos;);
-        ///
-        ///	INSERT INTO Cards (StackId, Question, Choice [rest of string was truncated]&quot;;.
+        ///   Looks up a localized string similar to -- Flashcards: Assign Box values (1=daily, 2=every 3 days, 3=every 7 days)
+        ///INSERT INTO Cards (StackId, Front, Back, CardType, Box, NextReviewDate) VALUES
+        ///	(1, &apos;Hola&apos;, &apos;Hello&apos;, &apos;Flashcard&apos;, 1, GETDATE()),
+        ///	(1, &apos;¿Cómo estás?&apos;, &apos;How are you?&apos;, &apos;Flashcard&apos;, 1, GETDATE()),
+        ///	(1, &apos;Gracias&apos;, &apos;Thank you&apos;, &apos;Flashcard&apos;, 2, DATEADD(day, 3, GETDATE())),
+        ///	(2, &apos;Hallo&apos;, &apos;Hello&apos;, &apos;Flashcard&apos;, 1, GETDATE()),
+        ///	(2, &apos;Wie geht es dir?&apos;, &apos;How are you?&apos;, &apos;Flashcard&apos;, 2, DATEADD(day, 3, GETDATE())),
+        ///	(2, &apos;Danke&apos;, &apos;Thank you&apos; [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string SeedCards {
             get {

--- a/Flashcards/SqlScripts/CreateTables.sql
+++ b/Flashcards/SqlScripts/CreateTables.sql
@@ -28,6 +28,8 @@ CREATE TABLE Cards (
     ClozeText NVARCHAR(max) NULL,
     FillInText NVARCHAR(max) NULL,
     Answer NVARCHAR(max) NULL,
+    Box INT NOT NULL DEFAULT 1,
+    NextReviewDate DATE NOT NULL DEFAULT GETDATE(),
     CardType NVARCHAR(30) NOT NULL,
     CHECK (CardType IN ('Flashcard', 'Cloze', 'MultipleChoice', 'FillIn')),
     FOREIGN KEY (StackId) REFERENCES Stacks(Id)

--- a/Flashcards/SqlScripts/SeedCards.sql
+++ b/Flashcards/SqlScripts/SeedCards.sql
@@ -1,21 +1,22 @@
-INSERT INTO Cards (StackId, Front, Back, CardType) VALUES
-	(1, 'Hola', 'Hello', 'Flashcard'),
-	(1, '¿Cómo estás?', 'How are you?', 'Flashcard'),
-	(1, 'Gracias', 'Thank you', 'Flashcard'),
-	(2, 'Hallo', 'Hello', 'Flashcard'),
-	(2, 'Wie geht es dir?', 'How are you?', 'Flashcard'),
-	(2, 'Danke', 'Thank you', 'Flashcard'),
-	(3, 'Dzień dobry', 'Good morning', 'Flashcard'),
-	(3, 'Do widzenia', 'Goodbye', 'Flashcard'),
-	(3, 'Proszę', 'Please', 'Flashcard');
+-- Flashcards: Assign Box values (1=daily, 2=every 3 days, 3=every 7 days)
+INSERT INTO Cards (StackId, Front, Back, CardType, Box, NextReviewDate) VALUES
+	(1, 'Hola', 'Hello', 'Flashcard', 1, GETDATE()),
+	(1, '¿Cómo estás?', 'How are you?', 'Flashcard', 1, GETDATE()),
+	(1, 'Gracias', 'Thank you', 'Flashcard', 2, DATEADD(day, 3, GETDATE())),
+	(2, 'Hallo', 'Hello', 'Flashcard', 1, GETDATE()),
+	(2, 'Wie geht es dir?', 'How are you?', 'Flashcard', 2, DATEADD(day, 3, GETDATE())),
+	(2, 'Danke', 'Thank you', 'Flashcard', 3, DATEADD(day, 7, GETDATE())),
+	(3, 'Dzień dobry', 'Good morning', 'Flashcard', 1, GETDATE()),
+	(3, 'Do widzenia', 'Goodbye', 'Flashcard', 2, DATEADD(day, 3, GETDATE())),
+	(3, 'Proszę', 'Please', 'Flashcard', 3, DATEADD(day, 7, GETDATE()));
 
-INSERT INTO Cards (StackId, Question, Choices, Answer, CardType) VALUES
-    (3, 'Jakie jest największe miasto w Polsce?', 'Kraków;Warszawa;Gdańsk;Wrocław', 'Warszawa', 'MultipleChoice'),
-	(3, 'Które z tych są polskimi rzekami?', 'Wisła;Odra;Ren;Dunaj;Warta', 'Wisła;Odra;Warta', 'MultipleChoice'),
-	(3, 'Ile województw ma Polska?', 'Czternaście;Piętnaście;Szesnaście;Siedemnaście', 'Szesnaście', 'MultipleChoice');
+INSERT INTO Cards (StackId, Question, Choices, Answer, CardType, Box, NextReviewDate) VALUES
+    (3, 'Jakie jest największe miasto w Polsce?', 'Kraków;Warszawa;Gdańsk;Wrocław', 'Warszawa', 'MultipleChoice', 1, GETDATE()),
+	(3, 'Które z tych są polskimi rzekami?', 'Wisła;Odra;Ren;Dunaj;Warta', 'Wisła;Odra;Warta', 'MultipleChoice', 2, DATEADD(day, 3, GETDATE())),
+	(3, 'Ile województw ma Polska?', 'Czternaście;Piętnaście;Szesnaście;Siedemnaście', 'Szesnaście', 'MultipleChoice', 3, DATEADD(day, 7, GETDATE()));
 
-INSERT INTO Cards (StackId, ClozeText, CardType) VALUES
-    (2, 'Guten {{c1::Morgen}}!', 'Cloze'),
-    (2, 'Ich {{c1::heiße}} Anna.', 'Cloze'),
-    (2, 'Wie {{c1::geht}} es {{c2::dir}}?', 'Cloze'),
-    (2, 'Ich komme aus {{c1::Deutschland}}.', 'Cloze');
+INSERT INTO Cards (StackId, ClozeText, CardType, Box, NextReviewDate) VALUES
+    (2, 'Guten {{c1::Morgen}}!', 'Cloze', 1, GETDATE()),
+    (2, 'Ich {{c1::heiße}} Anna.', 'Cloze', 2, DATEADD(day, 3, GETDATE())),
+    (2, 'Wie {{c1::geht}} es {{c2::dir}}?', 'Cloze', 3, DATEADD(day, 7, GETDATE())),
+    (2, 'Ich komme aus {{c1::Deutschland}}.', 'Cloze', 1, GETDATE());


### PR DESCRIPTION
#### Summary
This pull request introduces new fields to the `Cards` table to support spaced repetition by tracking review intervals. It updates the relevant SQL scripts to accommodate these changes.

#### Changes
- `SqlScripts.Designer.cs`: Added localized string for seeding cards with `Box` and `NextReviewDate`.
- `CreateTables.sql`: Updated `Cards` table schema to include `Box` and `NextReviewDate` columns with default values.
- `SeedCards.sql`: Modified insertion statements to include values for `Box` and `NextReviewDate`.
