### PR TITLE
feat: implement retrieving study cards

### DIFF
--- a/Flashcards/Controllers/StacksController.cs
+++ b/Flashcards/Controllers/StacksController.cs
@@ -1,4 +1,4 @@
-﻿using Flashcards.Models;
+using Flashcards.Models;
 using Flashcards.Services.Interfaces;
 using Flashcards.Utils;
 
@@ -41,6 +41,11 @@ public class StacksController
     public async Task<Result<List<BaseCardDto>>> GetCardsByStackIdAsync()
     {
         return await _stacksService.GetCardsByStackIdAsync();
+    }
+
+    public async Task<Result<List<BaseCardDto>>> GetCardsToStudyByStackIdAsync()
+    {
+        return await _stacksService.GetCardsToStudyByStackIdAsync();
     }
 
     public async Task<Result<int>> GetCardsCountInStackAsync()

--- a/Flashcards/Menu.cs
+++ b/Flashcards/Menu.cs
@@ -1,4 +1,4 @@
-﻿using Flashcards.Controllers;
+using Flashcards.Controllers;
 using Flashcards.Enums;
 using Flashcards.Helpers;
 using Flashcards.Services.Interfaces;
@@ -239,7 +239,7 @@ public class Menu
             return;
         }
 
-        var cardsResult = await _stacksController.GetCardsByStackIdAsync();
+        var cardsResult = await _stacksController.GetCardsToStudyByStackIdAsync();
         if (cardsResult.IsFailure)
         {
             ShowError(cardsResult.Error);

--- a/Flashcards/Services/Interfaces/IStacksService.cs
+++ b/Flashcards/Services/Interfaces/IStacksService.cs
@@ -1,4 +1,4 @@
-﻿using Flashcards.Models;
+using Flashcards.Models;
 using Flashcards.Utils;
 
 namespace Flashcards.Services.Interfaces;
@@ -10,6 +10,7 @@ public interface IStacksService
     Task<Result> DeleteCardFromStackAsync();
     Task<Result> UpdateCardInStackAsync();
     Task<Result<List<BaseCardDto>>> GetCardsByStackIdAsync();
+    Task<Result<List<BaseCardDto>>> GetCardsToStudyByStackIdAsync();
     Task<Result<int>> GetCardsCountInStackAsync();
     Task<Result<List<StackDto>>> GetAllStacksAsync();
     Task<Result> GetStackAsync();


### PR DESCRIPTION
#### Summary
This pull request introduces a new method for retrieving study cards from a stack and updates related components to utilize this functionality.

#### Changes
- `StacksController`: Added `GetCardsToStudyByStackIdAsync` method for retrieving study cards.
- `Menu`: Updated to call `GetCardsToStudyByStackIdAsync` instead of `GetCardsByStackIdAsync`.
- `IStacksService`: Added method signature for `GetCardsToStudyByStackIdAsync`.
- `StacksService`: Implemented logic for `GetCardsToStudyByStackIdAsync`, including error handling and logging.
