### PR TITLE
feat: show more detailed information about stacks before studying

### DIFF
--- a/Flashcards/Controllers/StacksController.cs
+++ b/Flashcards/Controllers/StacksController.cs
@@ -58,9 +58,19 @@ public class StacksController
         return await _stacksService.GetAllStacksAsync();
     }
 
+    public async Task<Result<List<StackSummaryDto>>> GetAllStackSummariesAsync()
+    {
+        return await _stacksService.GetAllStackSummariesAsync();
+    }
+
     public async Task<Result> GetStackAsync()
     {
         return await _stacksService.GetStackAsync();
+    }
+
+    public async Task<Result> GetStackToStudyAsync()
+    {
+        return await _stacksService.GetStackToStudyAsync();
     }
 
     public Stack GetCurrentStack()

--- a/Flashcards/DataAccess/Interfaces/IStacksRepository.cs
+++ b/Flashcards/DataAccess/Interfaces/IStacksRepository.cs
@@ -23,4 +23,5 @@ public interface IStacksRepository
     Task<Result> AddStackAsync(string name);
     Task<Result<IEnumerable<Stack>>> GetAllStacksAsync();
     Task<Result<bool>> StackExistsWithNameAsync(string name);
+    Task<Result<IEnumerable<StackSummaryDto>>> GetAllStackSummariesAsync();
 }

--- a/Flashcards/DataAccess/Repositories/StacksRepository.cs
+++ b/Flashcards/DataAccess/Repositories/StacksRepository.cs
@@ -396,4 +396,29 @@ public class StacksRepository : IStacksRepository
             return Result.Failure<IEnumerable<BaseCard>>(CardsErrors.GetAllFailed);
         }
     }
+
+    public async Task<Result<IEnumerable<StackSummaryDto>>> GetAllStackSummariesAsync()
+    {
+        _logger.LogInformation("Retrieving all stack summaries.");
+        try
+        {
+            using (var connection = new SqlConnection(_defaultConnectionString))
+            {
+                string sql = SqlScripts.GetAllStackSummaries;
+                var summaries = await connection.QueryAsync<StackSummaryDto>(sql);
+                _logger.LogInformation("Successfully retrieved {Count} stack summaries.", summaries.Count());
+                return Result.Success(summaries);
+            }
+        }
+        catch (SqlException ex)
+        {
+            _logger.LogError(ex, "SQL error while retrieving all stack summaries.");
+            return Result.Failure<IEnumerable<StackSummaryDto>>(StacksErrors.GetStacksFailed);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unexpected error while retrieving all stack summaries.");
+            return Result.Failure<IEnumerable<StackSummaryDto>>(StacksErrors.GetStacksFailed);
+        }
+    }
 }

--- a/Flashcards/Helpers/DataVisualizer.cs
+++ b/Flashcards/Helpers/DataVisualizer.cs
@@ -1,4 +1,4 @@
-﻿using Flashcards.Models;
+using Flashcards.Models;
 
 using Spectre.Console;
 
@@ -61,6 +61,27 @@ public static class DataVisualizer
         foreach (StackDto stack in stacks)
         {
             table.AddRow(stack.Name);
+        }
+
+        AnsiConsole.Write(table);
+    }
+
+    public static void ShowStacksSummary(List<StackSummaryDto> stackSummaries)
+    {
+        if (stackSummaries is [])
+        {
+            AnsiConsole.MarkupLine("No stacks found.");
+            return;
+        }
+        var table = new Table().Title("STACKS SUMMARY");
+
+        table.AddColumn("Name");
+        table.AddColumn("Due Cards");
+        table.AddColumn("Total Cards");
+
+        foreach (StackSummaryDto stackSummary in stackSummaries)
+        {
+            table.AddRow(stackSummary.Name, stackSummary.DueCards.ToString(), stackSummary.TotalCards.ToString());
         }
 
         AnsiConsole.Write(table);

--- a/Flashcards/Menu.cs
+++ b/Flashcards/Menu.cs
@@ -230,7 +230,10 @@ public class Menu
 
     private async Task StudyAsync()
     {
-        var stackResult = await _stacksController.GetStackAsync();
+        var stackSummaries = await _stacksController.GetAllStackSummariesAsync();
+        DataVisualizer.ShowStacksSummary(stackSummaries.Value);
+
+        var stackResult = await _stacksController.GetStackToStudyAsync();
         if (stackResult.IsFailure)
         {
             ShowError(stackResult.Error);

--- a/Flashcards/Models/Stack.cs
+++ b/Flashcards/Models/Stack.cs
@@ -1,4 +1,4 @@
-﻿namespace Flashcards.Models;
+namespace Flashcards.Models;
 
 public class Stack
 {
@@ -10,4 +10,11 @@ public class Stack
 public record class StackDto
 {
     public string Name { get; init; }
+}
+
+public record class StackSummaryDto
+{
+    public string Name { get; init; }
+    public int TotalCards { get; init; }
+    public int DueCards { get; init; }
 }

--- a/Flashcards/Services/Interfaces/IStacksService.cs
+++ b/Flashcards/Services/Interfaces/IStacksService.cs
@@ -15,5 +15,6 @@ public interface IStacksService
     Task<Result<List<StackDto>>> GetAllStacksAsync();
     Task<Result<List<StackSummaryDto>>> GetAllStackSummariesAsync();
     Task<Result> GetStackAsync();
+    Task<Result> GetStackToStudyAsync();
     Stack GetCurrentStack();
 }

--- a/Flashcards/Services/Interfaces/IStacksService.cs
+++ b/Flashcards/Services/Interfaces/IStacksService.cs
@@ -13,6 +13,7 @@ public interface IStacksService
     Task<Result<List<BaseCardDto>>> GetCardsToStudyByStackIdAsync();
     Task<Result<int>> GetCardsCountInStackAsync();
     Task<Result<List<StackDto>>> GetAllStacksAsync();
+    Task<Result<List<StackSummaryDto>>> GetAllStackSummariesAsync();
     Task<Result> GetStackAsync();
     Stack GetCurrentStack();
 }

--- a/Flashcards/Services/Interfaces/IUserInteractionService.cs
+++ b/Flashcards/Services/Interfaces/IUserInteractionService.cs
@@ -20,6 +20,7 @@ public interface IUserInteractionService
     CardType GetCardType();
     BaseCardDto GetCard(List<BaseCardDto> cards);
     string GetStack(List<StackDto> stacks);
+    string GetStack(List<StackSummaryDto> stackSummaryDtos);
     MenuOptions GetMenuOption();
     ManageStackOptions GetManageStackOption(string currentStack);
     ManageCardsOptions GetManageCardsOption();

--- a/Flashcards/Services/StacksService.cs
+++ b/Flashcards/Services/StacksService.cs
@@ -255,6 +255,20 @@ public class StacksService : IStacksService
         return Result.Success(stackDtos);
     }
 
+    public async Task<Result<List<StackSummaryDto>>> GetAllStackSummariesAsync()
+    {
+        _logger.LogInformation("Starting GetAllStackSummariesAsync.");
+        var stacksResult = await _stacksRepository.GetAllStackSummariesAsync();
+        if (stacksResult.IsFailure)
+        {
+            _logger.LogWarning("Failed to retrieve stack summaries: {Error}", stacksResult.Error.Description);
+            return Result.Failure<List<StackSummaryDto>>(stacksResult.Error);
+        }
+
+        _logger.LogInformation("Retrieved {Count} stack summaries.", stacksResult.Value.Count());
+        return Result.Success(stacksResult.Value.ToList());
+    }
+
     public async Task<Result> GetStackAsync()
     {
         _logger.LogInformation("Starting GetStackAsync.");

--- a/Flashcards/Services/UserInteractionService.cs
+++ b/Flashcards/Services/UserInteractionService.cs
@@ -93,6 +93,15 @@ public class UserInteractionService : IUserInteractionService
             );
     }
 
+    public string GetStack(List<StackSummaryDto> stackSummaryDtos)
+    {
+        return AnsiConsole.Prompt(
+            new SelectionPrompt<string>()
+                .Title("Choose your stack")
+                .AddChoices(stackSummaryDtos.Select(f => f.Name))
+            );
+    }
+
     public MenuOptions GetMenuOption()
     {
         return AnsiConsole.Prompt(

--- a/Flashcards/SqlScripts.Designer.cs
+++ b/Flashcards/SqlScripts.Designer.cs
@@ -224,6 +224,23 @@ namespace Flashcards {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to SELECT
+        ///    s.Name,
+        ///    COUNT(
+        ///        CASE WHEN c.NextReviewDate &lt;= CAST(GETDATE() AS DATE) THEN 1 END
+        ///    ) AS DueCards,
+        ///    COUNT(c.Id) AS TotalCards
+        ///FROM Stacks s
+        ///    JOIN Cards c ON s.Id = c.StackId
+        ///GROUP BY s.Name;.
+        /// </summary>
+        internal static string GetAllStackSummaries {
+            get {
+                return ResourceManager.GetString("GetAllStackSummaries", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to SELECT * FROM Cards.
         /// </summary>
         internal static string GetCards {

--- a/Flashcards/SqlScripts.resx
+++ b/Flashcards/SqlScripts.resx
@@ -154,6 +154,9 @@
   <data name="DeleteStack" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>SqlScripts\DeleteStack.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;windows-1250</value>
   </data>
+  <data name="GetAllStackSummaries" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>SqlScripts\GetAllStackSummaries.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;windows-1250</value>
+  </data>
   <data name="GetCards" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>SqlScripts\GetCards.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;windows-1250</value>
   </data>

--- a/Flashcards/SqlScripts/GetAllStackSummaries.sql
+++ b/Flashcards/SqlScripts/GetAllStackSummaries.sql
@@ -1,0 +1,9 @@
+SELECT
+    s.Name,
+    COUNT(
+        CASE WHEN c.NextReviewDate <= CAST(GETDATE() AS DATE) THEN 1 END
+    ) AS DueCards,
+    COUNT(c.Id) AS TotalCards
+FROM Stacks s
+    JOIN Cards c ON s.Id = c.StackId
+GROUP BY s.Name;


### PR DESCRIPTION
#### Summary
This pull request introduces new methods for retrieving stack summaries and a specific stack to study. Additionally. users can see more detailed information about stacks before studying (due and total cards).

#### Changes
- `StacksController`: Added `GetAllStackSummariesAsync` and `GetStackToStudyAsync` methods.
- `IStacksRepository`: Introduced `GetAllStackSummariesAsync` method for stack summary retrieval.
- `StacksRepository`: Implemented `GetAllStackSummariesAsync` with logging and error handling.
- `DataVisualizer`: Added `ShowStacksSummary` method to display stack summaries in a table format.
- `Stack`: Created `StackSummaryDto` record class to encapsulate stack summary information.
