### PR TITLE
test: add unit tests for spaced repetition

### DIFF
--- a/Flashcards.UnitTests/Services/StudySessionsServiceTests.cs
+++ b/Flashcards.UnitTests/Services/StudySessionsServiceTests.cs
@@ -440,4 +440,23 @@ public class StudySessionsServiceTests
         var method = typeof(StudySessionsService).GetMethod("GetNextReviewDate", BindingFlags.NonPublic | BindingFlags.Static);
         return (DateTime)method.Invoke(null, new object[] { isCorrect, currentBox });
     }
+
+    [Fact]
+    public async Task StartStudySessionAsync_ShouldReturnFailure_WhenUpdateCardsProgressBulkAsyncFails()
+    {
+        // Arrange
+        var flashcard = new FlashcardDto { Id = 1, Front = "Hello", Back = "Hola", CardType = CardType.Flashcard };
+        var cards = new List<BaseCardDto> { flashcard };
+
+        _userInteractionService.GetAnswer().Returns("Hola");
+        _cardsRepository.UpdateCardsProgressBulkAsync(Arg.Any<IEnumerable<CardProgressUpdateDto>>())
+            .Returns(Result.Failure(CardsErrors.UpdateCardProgressFailed));
+
+        // Act
+        var result = await _studySessionsService.StartStudySessionAsync(cards);
+
+        // Assert
+        Assert.True(result.IsFailure);
+        Assert.Equal(CardsErrors.UpdateCardProgressFailed, result.Error);
+    }
 }

--- a/Flashcards.UnitTests/Services/StudySessionsServiceTests.cs
+++ b/Flashcards.UnitTests/Services/StudySessionsServiceTests.cs
@@ -459,4 +459,24 @@ public class StudySessionsServiceTests
         Assert.True(result.IsFailure);
         Assert.Equal(CardsErrors.UpdateCardProgressFailed, result.Error);
     }
+
+    [Fact]
+    public async Task RunStudySessionAsync_ShouldReturnFailure_WhenStartStudySessionAsyncFails()
+    {
+        // Arrange
+        var flashcard = new FlashcardDto { Id = 1, Front = "Hello", Back = "Hola", CardType = CardType.Flashcard };
+        var cards = new List<BaseCardDto> { flashcard };
+        int stackId = 1;
+
+        _userInteractionService.GetAnswer().Returns("Hola");
+        _cardsRepository.UpdateCardsProgressBulkAsync(Arg.Any<IEnumerable<CardProgressUpdateDto>>())
+            .Returns(Result.Failure(CardsErrors.UpdateCardProgressFailed));
+
+        // Act
+        var result = await _studySessionsService.RunStudySessionAsync(cards, stackId);
+
+        // Assert
+        Assert.True(result.IsFailure);
+        Assert.Equal(CardsErrors.UpdateCardProgressFailed, result.Error);
+    }
 }

--- a/Flashcards.UnitTests/Services/StudySessionsServiceTests.cs
+++ b/Flashcards.UnitTests/Services/StudySessionsServiceTests.cs
@@ -401,9 +401,43 @@ public class StudySessionsServiceTests
         // Assert
         Assert.Equal(expectedBox, nextBox);
     }
+
+    [Theory]
+    [InlineData(1, true, 1)]
+    [InlineData(2, true, 3)]
+    [InlineData(3, true, 7)]
+    [InlineData(1, false, 0)]
+    [InlineData(2, false, 0)]
+    [InlineData(3, false, 0)]
+    public void GetNextReviewDate_ShouldReturnExpectedDate(int currentBox, bool isCorrect, int expectedDays)
+    {
+        // Arrange
+        var before = DateTime.Now;
+
+        // Act
+        var nextReview = InvokeGetNextReviewDate(isCorrect, currentBox);
+
+        // Assert
+        if (isCorrect)
+        {
+            var delta = (nextReview.Date - before.Date).Days;
+            Assert.Equal(expectedDays, delta);
+        }
+        else
+        {
+            Assert.Equal(before.Date, nextReview.Date);
+        }
+    }
+
     private static int InvokeGetNextBox(bool isCorrect, int currentBox)
     {
         var method = typeof(StudySessionsService).GetMethod("GetNextBox", BindingFlags.NonPublic | BindingFlags.Static);
         return (int)method.Invoke(null, new object[] { isCorrect, currentBox });
+    }
+
+    private static DateTime InvokeGetNextReviewDate(bool isCorrect, int currentBox)
+    {
+        var method = typeof(StudySessionsService).GetMethod("GetNextReviewDate", BindingFlags.NonPublic | BindingFlags.Static);
+        return (DateTime)method.Invoke(null, new object[] { isCorrect, currentBox });
     }
 }

--- a/Flashcards.UnitTests/Services/StudySessionsServiceTests.cs
+++ b/Flashcards.UnitTests/Services/StudySessionsServiceTests.cs
@@ -479,4 +479,18 @@ public class StudySessionsServiceTests
         Assert.True(result.IsFailure);
         Assert.Equal(CardsErrors.UpdateCardProgressFailed, result.Error);
     }
+
+    [Fact]
+    public async Task GetAllStudySessionsAsync_ShouldReturnFailure_WhenHasStudySessionAsyncFails()
+    {
+        // Arrange
+        _studySessionsRepository.HasStudySessionAsync().Returns(Result.Failure<bool>(StudySessionsErrors.HasStudySessionFailed));
+
+        // Act
+        var result = await _studySessionsService.GetAllStudySessionsAsync();
+
+        // Assert
+        Assert.True(result.IsFailure);
+        Assert.Equal(StudySessionsErrors.HasStudySessionFailed, result.Error);
+    }
 }

--- a/Flashcards.UnitTests/Services/StudySessionsServiceTests.cs
+++ b/Flashcards.UnitTests/Services/StudySessionsServiceTests.cs
@@ -1,3 +1,5 @@
+using System.Reflection;
+
 using Flashcards.DataAccess.Interfaces;
 using Flashcards.Models;
 using Flashcards.Services;
@@ -382,5 +384,26 @@ public class StudySessionsServiceTests
 
         // Assert
         Assert.True(result.IsSuccess);
+    }
+
+    [Theory]
+    [InlineData(1, true, 2)]
+    [InlineData(2, true, 3)]
+    [InlineData(3, true, 3)]
+    [InlineData(1, false, 1)]
+    [InlineData(2, false, 1)]
+    [InlineData(3, false, 1)]
+    public void GetNextBox_ShouldReturnExpectedBox(int currentBox, bool isCorrect, int expectedBox)
+    {
+        // Act
+        var nextBox = InvokeGetNextBox(isCorrect, currentBox);
+
+        // Assert
+        Assert.Equal(expectedBox, nextBox);
+    }
+    private static int InvokeGetNextBox(bool isCorrect, int currentBox)
+    {
+        var method = typeof(StudySessionsService).GetMethod("GetNextBox", BindingFlags.NonPublic | BindingFlags.Static);
+        return (int)method.Invoke(null, new object[] { isCorrect, currentBox });
     }
 }

--- a/Flashcards/Models/Flashcard.cs
+++ b/Flashcards/Models/Flashcard.cs
@@ -41,8 +41,8 @@ public abstract record class BaseCardDto
 {
     public int Id { get; init; }
     public CardType CardType { get; init; }
-    public int Box { get; init; }
-    public DateTime NextReviewDate { get; init; }
+    public int Box { get; init; } = 1;
+    public DateTime NextReviewDate { get; init; } = DateTime.Now;
 }
 
 public record class FlashcardDto : BaseCardDto


### PR DESCRIPTION
#### Summary
This pull request adds unit tests for various methods in the `StudySessionsService` and modifies the `BaseCardDto` class to include default property values.

#### Changes
- `StudySessionsServiceTests.cs`: Added unit tests for `GetNextBox`, `GetNextReviewDate`, `StartStudySessionAsync`, `RunStudySessionAsync`, and `GetAllStudySessionsAsync`.
- `StudySessionsServiceTests.cs`: Introduced reflection methods `InvokeGetNextBox` and `InvokeGetNextReviewDate` for testing private methods.
- `Flashcard.cs`: Updated `BaseCardDto` to set default values for `Box` (defaulting to `1`) and `NextReviewDate` (defaulting to `DateTime.Now`).
