### PR TITLE
refactor: use abstract factory pattern for card strategy instantiation

### DIFF
--- a/Flashcards.IntegrationTests/TestClassFixture.cs
+++ b/Flashcards.IntegrationTests/TestClassFixture.cs
@@ -1,8 +1,9 @@
-﻿using Flashcards.Controllers;
+using Flashcards.Controllers;
 using Flashcards.DataAccess;
 using Flashcards.DataAccess.Interfaces;
 using Flashcards.DataAccess.Repositories;
 using Flashcards.Services;
+using Flashcards.Services.CardStrategies;
 using Flashcards.Services.Interfaces;
 
 using Microsoft.Extensions.Configuration;
@@ -86,6 +87,7 @@ public class TestClassFixture : IAsyncLifetime
                 services.AddScoped<IStudySessionsRepository, StudySessionsRepository>();
                 services.AddScoped<IStudySessionsService, StudySessionsService>();
                 services.AddScoped<IStacksService, StacksService>();
+                services.AddScoped<ICardStrategyFactory, CardStrategyFactory>();
                 services.AddSingleton<ICardsService, CardsService>();
                 services.AddSingleton<StacksController>();
                 services.AddSingleton<StudySessionsController>();

--- a/Flashcards/Program.cs
+++ b/Flashcards/Program.cs
@@ -1,9 +1,10 @@
-﻿using Flashcards;
+using Flashcards;
 using Flashcards.Controllers;
 using Flashcards.DataAccess;
 using Flashcards.DataAccess.Interfaces;
 using Flashcards.DataAccess.Repositories;
 using Flashcards.Services;
+using Flashcards.Services.CardStrategies;
 using Flashcards.Services.Interfaces;
 
 using Microsoft.Extensions.Configuration;
@@ -57,6 +58,7 @@ var host = Host.CreateDefaultBuilder(args)
             services.AddScoped<IStudySessionsRepository, StudySessionsRepository>();
             services.AddScoped<IStudySessionsService, StudySessionsService>();
             services.AddScoped<IStacksService, StacksService>();
+            services.AddScoped<ICardStrategyFactory, CardStrategyFactory>();
             services.AddSingleton<ICardsService, CardsService>();
             services.AddSingleton<StacksController>();
             services.AddSingleton<StudySessionsController>();

--- a/Flashcards/Services/CardStrategies/CardStrategyFactory.cs
+++ b/Flashcards/Services/CardStrategies/CardStrategyFactory.cs
@@ -1,0 +1,38 @@
+using Flashcards.DataAccess.Interfaces;
+using Flashcards.Models;
+using Flashcards.Services.Interfaces;
+
+namespace Flashcards.Services.CardStrategies;
+public class CardStrategyFactory : ICardStrategyFactory
+{
+    private readonly ICardsRepository _cardsRepository;
+    private readonly IUserInteractionService _userInteractionService;
+
+    public CardStrategyFactory(ICardsRepository cardsRepository, IUserInteractionService userInteractionService)
+    {
+        _cardsRepository = cardsRepository;
+        _userInteractionService = userInteractionService;
+    }
+
+    public ICardStrategy GetCardStrategy(CardType cardType)
+    {
+        return cardType switch
+        {
+            CardType.Flashcard => new FlashcardStrategy(_cardsRepository, _userInteractionService),
+            CardType.MultipleChoice => new MultipleChoiceCardStrategy(_cardsRepository, _userInteractionService),
+            CardType.Cloze => new ClozeCardStrategy(_cardsRepository, _userInteractionService),
+            _ => throw new InvalidOperationException($"Unsupported card type: {cardType}")
+        };
+    }
+
+    public ICardStrategy GetCardStrategyForStack(CardType cardType, IStacksRepository stacksRepository)
+    {
+        return cardType switch
+        {
+            CardType.Flashcard => new FlashcardStrategy(_cardsRepository, _userInteractionService, stacksRepository),
+            CardType.MultipleChoice => new MultipleChoiceCardStrategy(_cardsRepository, _userInteractionService, stacksRepository),
+            CardType.Cloze => new ClozeCardStrategy(_cardsRepository, _userInteractionService, stacksRepository),
+            _ => throw new InvalidOperationException($"Unsupported card type: {cardType}")
+        };
+    }
+}

--- a/Flashcards/Services/Interfaces/ICardStrategyFactory.cs
+++ b/Flashcards/Services/Interfaces/ICardStrategyFactory.cs
@@ -1,0 +1,10 @@
+using Flashcards.DataAccess.Interfaces;
+using Flashcards.Models;
+using Flashcards.Services.CardStrategies;
+
+namespace Flashcards.Services.Interfaces;
+public interface ICardStrategyFactory
+{
+    ICardStrategy GetCardStrategy(CardType cardType);
+    ICardStrategy GetCardStrategyForStack(CardType cardType, IStacksRepository stacksRepository);
+}


### PR DESCRIPTION
#### Summary
This pull request introduces a `CardStrategyFactory` to instantiate different card strategies in `CardsService` and `StacksService`.

#### Changes
- `CardStrategyFactory.cs`: New class created to encapsulate card strategy creation logic.
- `ICardStrategyFactory.cs`: New interface defined for obtaining card strategies.
- `CardsService.cs`: Refactored to use `ICardStrategyFactory` for strategy instantiation.
- `StacksService.cs`: Updated to utilize `ICardStrategyFactory` for managing card strategies.
- `CardsServiceTests.cs` and `StacksServiceTests.cs`: Tests modified to use the new factory for obtaining card strategies
